### PR TITLE
Fixed reading of configuration ack

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -180,7 +180,6 @@ void Driver::startAcquisition()
     writePacket(reinterpret_cast<uint8_t const*>("PD0\n"), 4, 100);
     readConfigurationAck();
     writePacket(reinterpret_cast<uint8_t const*>("CS\n"), 3, 100);
-    readConfigurationAck();
     mConfMode = false;
 }
 

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -11,6 +11,7 @@ Driver::Driver()
     , mConfMode(false)
     , mDesiredBaudrate(9600)
 {
+    m_read_timeout = base::Time::fromSeconds(1.);
     buffer.resize(1000000);
 }
 
@@ -43,7 +44,7 @@ void Driver::sendConfigurationFile(std::string const& file_name)
         line += "\n";
         std::cout << iodrivers_base::Driver::printable_com(line) << std::endl;
         writePacket(reinterpret_cast<uint8_t const*>(line.c_str()), line.length());
-        readConfigurationAck();
+        readConfigurationAck(m_read_timeout);
     }
 }
 
@@ -74,7 +75,7 @@ void Driver::setDeviceBaudrate(int rate)
     }
     uint8_t data[7] = { 'C', 'B', '0' + code, '1', '1', '\n', 0 };
     writePacket(data, 6, 100);
-    readConfigurationAck();
+    readConfigurationAck(m_read_timeout);
 }
 
 void Driver::read()
@@ -134,7 +135,7 @@ void Driver::setConfigurationMode()
         writePacket(reinterpret_cast<uint8_t const*>("\n"), 1, 100);
         try
         {
-            readConfigurationAck(base::Time::fromSeconds(0.1));
+            readConfigurationAck(m_read_timeout);
             clear();
             break;
         }
@@ -178,7 +179,7 @@ void Driver::startAcquisition()
         throw std::logic_error("not in configuration mode");
 
     writePacket(reinterpret_cast<uint8_t const*>("PD0\n"), 4, 100);
-    readConfigurationAck();
+    readConfigurationAck(m_read_timeout);
     writePacket(reinterpret_cast<uint8_t const*>("CS\n"), 3, 100);
     mConfMode = false;
 }


### PR DESCRIPTION
- avoid to read a configuration ack after start acquisition 
 After the acquisition was started, using the CS command, the device leaves the
configuration mode. Therefor no further configuration ack will be send.
My guess why this was working most of the time before is that there might have been
enough ack's in the buffer due to the carriage return's send in setConfigurationMode
- use read timeout property when reading the configuration ack 